### PR TITLE
Add a link to the Erlang port

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     <li><a href="http://github.com/hamcrest/ramcrest">Ruby</a></li>
     <li><a href="http://github.com/hamcrest/OCHamcrest">Objective C</a></li>
     <li><a href="http://code.google.com/p/hamcrest/downloads/list?q=label:PHP">PHP</a></li>
+    <li><a href="http://github.com/hyperthunk/hamcrest-erlang">Erlang</a></li>
    </ul>
 
    <footer>


### PR DESCRIPTION
I've added a link to the erlang port which, whilst development is rather slow, is still being actively maintained and used in a number of projects (including meck).
