### PR TITLE
Added link to matcha, a port of Hamcrest to modern C++

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
     <li><a href="https://github.com/carllerche/hamcrest-rust">Rust</a></li>
     <li><a href="https://www.npmjs.com/package/jshamcrest">JavaScript (JsHamcrest)</a></li>
     <li><a href="https://www.npmjs.com/package/hamjest">JavaScript (Hamjest)</a></li>
+    <li><a href="https://github.com/amorenoc/matcha">C++</a></li>
    </ul>
 
    <footer>


### PR DESCRIPTION
This is a port of Hamcrest to C++11, and implements almost all the hamcrest-core matchers, plus some others from the hamcrest-library. It's a header-only template library, and integrates with Boost and Google C++ Testing frameworks.
