### PR TITLE
proposal to add Gocrest

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
     <li><a href="https://github.com/carllerche/hamcrest-rust">Rust</a></li>
     <li><a href="https://www.npmjs.com/package/jshamcrest">JavaScript (JsHamcrest)</a></li>
     <li><a href="https://www.npmjs.com/package/hamjest">JavaScript (Hamjest)</a></li>
+    <li><a href="https://github.com/corbym/gocrest">GO (Gocrest)</a></li>
    </ul>
 
    <footer>


### PR DESCRIPTION
Hi,

I'm a long term Java engineer, loving to write and use hamcrest.
In my latest GO projects, I realized how much I miss to express my intent.
There's nothing close to Hamcrest in the GO world ...
EXCEPT: this little gem: https://github.com/corbym/gocrest

Hence, I do propose to add this library to the hamcrest homepage.
According to common open-source best practices, his library and repository look really well maintained.

Side note: even if it has just 11 stars, yet, it seems to me the most sophisticated implementation
for hamcrest like matchers. Other libs are either outdated or less well maintained.

Any feedback welcome.

#CommunityPower
I hope @corbym is fine with me, spreading the word here.
I would love to see more use of hamcrest like matchers in GO.