### PR TITLE
Adds eo-hamcrest to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
     <li><a href="https://www.npmjs.com/package/hamjest">JavaScript (Hamjest)</a></li>
     <li><a href="https://github.com/corbym/gocrest">GO (Gocrest)</a></li>
     <li><a href="https://github.com/nhamcrest/NHamcrest">C# (NHamcrest)</a></li>
+    <li><a href="https://github.com/objectionary/eo-hamcrest">EO (EO-Hamcrest)</a></li>
    </ul>
 
    <footer>


### PR DESCRIPTION
**[EO-Hamcrest](https://github.com/objectionary/eo-hamcrest)** is a collection of test matchers for [EO](https://www.eolang.org) in [Hamcrest](http://hamcrest.org) style.

**EO** (stands for [Elegant Objects](http://www.yegor256.com/elegant-objects.html) or ISO 639-1 code of [Esperanto](https://en.wikipedia.org/wiki/Esperanto)) is an object-oriented programming language based on [𝜑-calculus](https://arxiv.org/abs/2111.13384). 