### PR TITLE
DNS infrastructure terraform files

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,1 @@
+plan.just

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/go-gandi/gandi" {
+  version     = "2.3.0"
+  constraints = "~> 2.3.0"
+  hashes = [
+    "h1:PH6KI61eli5OL/aN3Oi7NV9qkNbjGLoOYjJK3gvULj4=",
+    "zh:0936d011cf75bb5162c6027d00575a586807adc9008f4152def157b6ad22bae9",
+    "zh:2170e671f04d3346ea416fcc404be6d05f637eab7df77e289a6898a928885f0b",
+    "zh:250329baae3cb09cfb88dd004d45f003ba76fbe7b8daf9d18fd640b93a2b7252",
+    "zh:2ccd9f253424738ca5fbbcb2127bf3713c20e87bfb3829f8c4565569424fd0bd",
+    "zh:3607b48bc4691cd209528f9ffe16a6cc666bd284b0d0bdfe8c4e1d538559a408",
+    "zh:3bc1d2b770fe0f50027da59c405b2468d1322243235367014f75f765124f458d",
+    "zh:6c8a9092847ee2e2890825432b54424c456638d494e49b7d1845f055214714f5",
+    "zh:8e0b62a330876005d52bcd65d7b1d9a679a7ac79c626e0f86661519e8f9b5698",
+    "zh:8f44f4d52583ff249e2001ea2a8b8841010489dd43e1a01a9ec3a6813d121c28",
+    "zh:9a617927d4a3a2897ff10999a19a6d1f0ef634b8c6b8fc3be12cf53948cfd9cf",
+    "zh:cab3c82c54e38e6001eed5b80a2d16b7824921f8f8b3909049e174c48e6e8804",
+    "zh:f78cc685aa4ba5056ea53a7f8ce585f87a911f0a8a387a44a33d7dfb69db7663",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.12.0"
+  constraints = ">= 4.67.0"
+  hashes = [
+    "h1:QiSzB4pjONZ4hek1L8Rcd6S9vtP+yMr5iOfczJg5/JI=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/infra/dns/main.tf
+++ b/infra/dns/main.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    gandi = {
+      version = "~> 2.3.0"
+      source  = "go-gandi/gandi"
+    }
+  }
+}
+variable "gandi_pat" {
+  type      = string
+  sensitive = true
+}
+
+provider "gandi" {
+  personal_access_token = var.gandi_pat
+}
+
+
+variable "domain" {
+  type = string
+}
+
+data "gandi_domain" "this" {
+  name = var.domain
+}
+
+resource "gandi_livedns_record" "a" {
+  name = "@"
+  type = "A"
+  ttl  = 3600
+  values = [
+    "185.199.110.153",
+    "185.199.111.153",
+    "185.199.109.153",
+    "185.199.108.153",
+  ]
+  zone = data.gandi_domain.this.name
+}
+
+resource "gandi_livedns_record" "www" {
+  name = "www"
+  type = "CNAME"
+  ttl  = 3600
+  values = [
+    "hamcrest.github.io."
+  ]
+  zone = data.gandi_domain.this.name
+}
+
+resource "gandi_livedns_record" "github_pages" {
+  name = "_github-pages-challenge-hamcrest"
+  type = "TXT"
+  ttl  = 10800
+  values = [
+    "\"109f0d722de274783b6d3065b747a2\""
+  ]
+  zone = data.gandi_domain.this.name
+}

--- a/infra/domain/main.tf
+++ b/infra/domain/main.tf
@@ -1,0 +1,13 @@
+variable "domain" {
+  type = string
+}
+
+variable "name_servers" {
+  type = list(string)
+}
+
+resource "null_resource" "updatens-domain" {
+  provisioner "local-exec" {
+    command = "aws route53domains update-domain-nameservers --region us-east-1 --domain-name ${var.domain} --nameservers Name=${var.name_servers.0} Name=${var.name_servers.1} Name=${var.name_servers.2} Name=${var.name_servers.3}"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "aws"
+      version = ">= 4.67.0"
+    }
+  }
+  required_version = ">= 1.13"
+
+  backend "s3" {
+    bucket  = "terraform.offby1.net"
+    key     = "hamcrest.org/state.tfstate"
+    region  = "us-west-2"
+    profile = "hamcrest"
+  }
+}
+
+provider "aws" {
+  profile = "hamcrest"
+  region  = "us-west-2"
+}
+
+variable "gandi_pat" {
+  type      = string
+  sensitive = true
+}
+
+module "dns" {
+  source    = "./dns/"
+  domain    = "hamcrest.org"
+  gandi_pat = var.gandi_pat
+}
+

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+venv_path := justfile_directory() / ".venv"
+set dotenv-load := true
+
+terraform := "terraform -chdir=" + justfile_directory() / "infra"
+
+default:
+    just --choose
+
+bootstrap:
+    {{ terraform}} init
+
+_make_plan:
+    #!/bin/bash
+    rm -f plan.just 2>/dev/null
+    plan_logs_file=$(mktemp)
+    trap 'rm -f "$plan_logs_file"' EXIT
+    {{terraform}} plan -out plan.just >"$plan_logs_file" 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error during terraform plan. See logs:"
+        cat "$plan_logs_file"
+        exit 1
+    fi
+
+show-plan:
+    @{{terraform}} show plan.just
+
+plan: _make_plan && show-plan
+
+apply:
+    {{terraform}} apply plan.just

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+terraform = "1.13"


### PR DESCRIPTION
Although this is not runnable directly, it does serve as a visible repository of the DNS configuration for hamcrest.org (we'd need to move the durable state into an S3 bucket we can all see in order for everyone to be able to run it)

This accurately captures the present day DNS config for hamcrest.org